### PR TITLE
fixing property-mapper

### DIFF
--- a/src/property-mapper.ts
+++ b/src/property-mapper.ts
@@ -17,6 +17,7 @@ export default function propertyMapper<T = any>(schema: T, transform: SwaggerToT
       Object.entries(node.properties).map(([key, val]) => {
         // if $ref, skip
         if (val.$ref) {
+          val.$ref = String(val.$ref)
           return [key, val];
         }
 


### PR DESCRIPTION
$refs under properties.properties in openapi get parsed into a naked wrapped string object, without any of the methods of string, passing $refs through a string transform to reattach the proper methods and not cause occasional crashes when running openapi-typescript with the propertyMapper option